### PR TITLE
:arrow_up: PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "swiftmailer/swiftmailer": "^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0"
+    "phpunit/phpunit": "^7.0"
   },
   "suggest": {
     "openbuildings/swiftmailer-css-inliner": "Inline css in your Swiftmailer messages"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Version 7 is the last to supports PHP 7.1, see https://phpunit.de/supported-versions.html

#4 